### PR TITLE
1.0.17

### DIFF
--- a/assets/js/console-vue.js
+++ b/assets/js/console-vue.js
@@ -34,14 +34,13 @@ export default {
 						:item="item"
 						:active="active"
 						:size-dependencies="[
-							item.content.text,
+							item.content,
 						]"
 						:data-index="index"
 						:data-active="active"
 						class="console-text-item"
-					>
-						<span :style="'color:' + (item.content.color ? item.content.color : 'black') + ';'">{{ item.content.text }}</span>
-					</DynamicScrollerItem>
+						v-html="item.content"
+					></DynamicScrollerItem>
 				</template>
 			</DynamicScroller>
 

--- a/assets/js/mini-console-vue.js
+++ b/assets/js/mini-console-vue.js
@@ -15,14 +15,13 @@ export default {
 					:item="item"
 					:active="active"
 					:size-dependencies="[
-						item.content.text,
+						item.content,
 					]"
 					:data-index="index"
 					:data-active="active"
 					class="console-text-item"
-				>
-					<span :style="'color:' + (item.content.color ? item.content.color : 'black') + ';'">{{ item.content.text }}</span>
-				</DynamicScrollerItem>
+					v-html="item.content"
+				></DynamicScrollerItem>
 			</template>
 		</DynamicScroller>
 	</b-card>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -39,6 +39,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-html"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ee82de0545b181a17cbdef44fce80ecaf394e001da7ea279008bf2e0944bee"
+dependencies = [
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2426,7 @@ dependencies = [
 name = "rl-bot-gui"
 version = "1.0.17"
 dependencies = [
+ "ansi-to-html",
  "base64",
  "fs_extra",
  "futures-util",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1463,9 +1463,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.129"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "line-wrap"
@@ -3018,9 +3018,11 @@ dependencies = [
  "minisign-verify",
  "objc",
  "once_cell",
+ "open",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
+ "regex",
  "reqwest",
  "rfd",
  "semver 1.0.13",
@@ -3076,6 +3078,7 @@ dependencies = [
  "png 0.17.5",
  "proc-macro2",
  "quote",
+ "regex",
  "semver 1.0.13",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "rl-bot-gui"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "base64",
  "fs_extra",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,11 +52,11 @@ registry = "1.2"
 
 [target.'cfg(not(any(windows, target_os = "macos")))'.dependencies.tauri]
 version = "1.0"
-features = ["devtools", "dialog", "reqwest-client"]
+features = ["devtools", "dialog", "reqwest-client", "shell-open"]
 
 [target.'cfg(any(windows, target_os = "macos"))'.dependencies.tauri]
 version = "1.0"
-features = ["devtools", "dialog", "reqwest-client", "updater"]
+features = ["devtools", "dialog", "reqwest-client", "shell-open", "updater"]
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "rl-bot-gui"
-version = "1.0.16"
+version = "1.0.17"
 description = "The RLBot GUI ported to Rust"
 authors = ["VirxEC"]
 license = "MIT"
 repository = "https://github.com/VirxEC/rlbot_gui_rust"
 default-run = "rl-bot-gui"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.63"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ serde-enum-str = "0.2.5"
 shlex = "1.1"
 thiserror = "1.0.31"
 indexmap = "1"
+ansi-to-html = "0.1.0"
 
 [target.'cfg(windows)'.dependencies]
 registry = "1.2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -218,7 +218,7 @@ pub async fn install_basic_packages(window: Window) -> Result<PackageResult, Str
 }
 
 #[tauri::command]
-pub async fn get_console_texts() -> Result<Vec<ConsoleText>, String> {
+pub async fn get_console_texts() -> Result<Vec<String>, String> {
     Ok(CONSOLE_TEXT.lock().map_err(|err| err.to_string())?.clone())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use crate::{
     config_handles::*,
     settings::{BotFolders, ConsoleText, ConsoleTextUpdate, GameTickPacket, StoryConfig, StoryState},
 };
-use lazy_static::{initialize, lazy_static};
+use lazy_static::lazy_static;
 use os_pipe::{pipe, PipeWriter};
 #[cfg(windows)]
 use registry::{Hive, Security};
@@ -49,15 +49,13 @@ const BOTPACK_REPO_OWNER: &str = "RLBot";
 const BOTPACK_REPO_NAME: &str = "RLBotPack";
 const MAX_CONSOLE_LINES: usize = 840;
 
-lazy_static! {
-    static ref CONSOLE_TEXT: Mutex<Vec<ConsoleText>> = Mutex::new(Vec::new());
-    static ref CONSOLE_TEXT_OUT_QUEUE: Mutex<Vec<String>> = Mutex::new(Vec::new());
-    static ref CONSOLE_INPUT_COMMANDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
-    static ref PYTHON_PATH: Mutex<String> = Mutex::new(String::new());
-    static ref BOT_FOLDER_SETTINGS: Mutex<Option<BotFolders>> = Mutex::new(None);
-    static ref MATCH_HANDLER_STDIN: Mutex<Option<ChildStdin>> = Mutex::new(None);
-    static ref CAPTURE_PIPE_WRITER: Mutex<Option<PipeWriter>> = Mutex::new(None);
-}
+static CONSOLE_TEXT: Mutex<Vec<ConsoleText>> = Mutex::new(Vec::new());
+static CONSOLE_TEXT_OUT_QUEUE: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static CONSOLE_INPUT_COMMANDS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static PYTHON_PATH: Mutex<String> = Mutex::new(String::new());
+static BOT_FOLDER_SETTINGS: Mutex<Option<BotFolders>> = Mutex::new(None);
+static MATCH_HANDLER_STDIN: Mutex<Option<ChildStdin>> = Mutex::new(None);
+static CAPTURE_PIPE_WRITER: Mutex<Option<PipeWriter>> = Mutex::new(None);
 
 lazy_static! {
     static ref BOTS_BASE: AsyncMutex<Option<JsonMap>> = AsyncMutex::new(None);
@@ -527,10 +525,6 @@ fn is_debug_build() -> bool {
 
 fn main() {
     println!("Config path: {}", get_config_path().display());
-
-    initialize(&CONSOLE_TEXT);
-    initialize(&CONSOLE_INPUT_COMMANDS);
-    initialize(&MATCH_HANDLER_STDIN);
 
     tauri::Builder::default()
         .setup(|app| gui_setup(app))

--- a/src-tauri/src/rlbot/setup_manager.rs
+++ b/src-tauri/src/rlbot/setup_manager.rs
@@ -4,7 +4,7 @@ const ROCKET_LEAGUE_PROGRAM_NAME: &str = if cfg!(windows) { "RocketLeague.exe" }
 const REQUIRED_ARGS: [&str; 2] = ["-rlbot", "RLBot_ControllerURL=127.0.0.1"];
 
 pub fn is_rocket_league_running(port: u16) -> Result<bool, String> {
-    let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new()));
+    let system = System::new_with_specifics(RefreshKind::new().with_processes(ProcessRefreshKind::new().with_user()));
     let mut rl_procs = system.processes_by_name(ROCKET_LEAGUE_PROGRAM_NAME);
     let port_arg = format!("{}:{port}", REQUIRED_ARGS[1]);
 
@@ -12,6 +12,7 @@ pub fn is_rocket_league_running(port: u16) -> Result<bool, String> {
         Some(process_info) => {
             let mut has_rlbot_arg = false;
             let mut has_port_arg = false;
+
             for arg in process_info.cmd().iter().skip(1) {
                 if arg == REQUIRED_ARGS[0] {
                     has_rlbot_arg = true;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -368,33 +368,21 @@ pub struct LogoUpdate {
     pub logo: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ConsoleText {
-    pub text: String,
-    pub color: Option<String>,
-}
-
-impl ConsoleText {
-    pub const fn from(text: String, color: Option<String>) -> ConsoleText {
-        ConsoleText { text, color }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConsoleTextUpdate {
-    pub content: ConsoleText,
+    pub content: String,
     pub replace_last: bool,
 }
 
 impl ConsoleTextUpdate {
-    const fn new(text: String, color: Option<String>, replace_last: bool) -> Self {
+    const fn new(text: String, replace_last: bool) -> Self {
         ConsoleTextUpdate {
-            content: ConsoleText::from(text, color),
+            content: text,
             replace_last,
         }
     }
 
-    pub fn from(text: String, replace_last: bool) -> Self {
+    pub fn from(mut text: String, replace_last: bool) -> Self {
         let color = {
             let text = text.to_ascii_lowercase();
             if text.contains("error") {
@@ -408,7 +396,11 @@ impl ConsoleTextUpdate {
             }
         };
 
-        ConsoleTextUpdate::new(text, color, replace_last)
+        if let Some(color) = color {
+            text = format!("<span style='color: {color}'>{text}</span>");
+        }
+
+        ConsoleTextUpdate::new(text, replace_last)
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,6 +8,11 @@
     "withGlobalTauri": true
   },
   "tauri": {
+    "allowlist": {
+      "shell": {
+        "open": true
+      }
+    },
     "bundle": {
       "active": true,
       "identifier": "org.rlbot.gui",


### PR DESCRIPTION
Use Rust 1.63 const mutex's
Fix not detecting Rocket League args and showing warning
Convert some ANSI escape characters to HTML (+ escape any HTML and simplify in-gui console)
Fix #12 